### PR TITLE
Fixes to avoid Memory Leaks - Missing virtual destructors 

### DIFF
--- a/stonne/include/DistributionNetwork.h
+++ b/stonne/include/DistributionNetwork.h
@@ -21,6 +21,7 @@ private:
 public:
     //General constructor, just used to heritage with unit
     DistributionNetwork(id_t id, std::string name) : Unit(id, name) {}
+    virtual ~DistributionNetwork() {} //Missing destructor call
     //This just executes cycle over all the dsnetworks
     virtual void cycle() {assert(false);} 
     //Get last levels connections together. Useful to connect with mswitches later.

--- a/stonne/include/MemoryController.h
+++ b/stonne/include/MemoryController.h
@@ -19,6 +19,7 @@
 class MemoryController : Unit {        
 public:
     MemoryController(id_t id, std::string name) : Unit(id, name){}
+    virtual ~MemoryController() {} //Missing destructor call
     virtual void setLayer(DNNLayer* dnn_layer,  address_t input_address, address_t filter_address, address_t output_address, Dataflow dataflow) {assert(false);}
     virtual void setTile(Tile* current_tile) {assert(false);}
     virtual void setReadConnections(std::vector<Connection*> read_connections) {assert(false);}

--- a/stonne/include/MultiplierNetwork.h
+++ b/stonne/include/MultiplierNetwork.h
@@ -21,6 +21,7 @@ public:
        input_ports, output_ports and forwarding_ports will be set as the single data size. If this implementation change for future tests, this can be change easily bu mofifying these three parameters.
      */
     MultiplierNetwork(id_t id, std::string name) : Unit(id, name){}
+    virtual ~MultiplierNetwork() {} //Missing destructor reference not called during runtime
     //set connections from the distribution network to the multiplier network
     virtual void setInputConnections(std::map<int, Connection*> input_connections) {assert(false);}
     //Set connections from the Multiplier Network to the Reduction Network

--- a/stonne/include/ReduceNetwork.h
+++ b/stonne/include/ReduceNetwork.h
@@ -20,6 +20,7 @@ class ReduceNetwork : public Unit{
     
 public:
     ReduceNetwork(id_t id, std::string name)  : Unit(id, name) {}
+    virtual ~ReduceNetwork() {} //Missing destructor call
     virtual void setMemoryConnections(std::vector<std::vector<Connection*>> memoryConnections) {assert(false);} //Connect all the memory ports from buses (busID, lineID) to its corresponding switches
     virtual std::map<int, Connection*> getLastLevelConnections() {assert(false);}
     virtual void setOutputConnection(Connection* outputConnection)  {assert(false);} //This function set the outputConnection with the Prefetch buffer

--- a/stonne/src/OSMeshMN.cpp
+++ b/stonne/src/OSMeshMN.cpp
@@ -47,7 +47,10 @@ OSMeshMN::~OSMeshMN() {
     }
 
 
-
+    //Delete accbuff connections also
+    for (auto it: accbufferconnectiontable) {
+        delete it.second;
+    }
 
 
 }


### PR DESCRIPTION
Hi Adrian,

Here are the changes we've discussed so far. The changes are only affecting the abstract classes of the HW components and including the virtual destructors, as described in https://www.quantstart.com/articles/C-Virtual-Destructors-How-to-Avoid-Memory-Leaks/. This change partially solves the most important memory leaks. Just to be bold clear about it: Stonne is still leaking after the change, but it reduces drastically the memory demands. These are the memory status of the testing results:

Memory before the commit with 300 iterations with pure STONNE, following parameters:
-FC -M=100 -K=196 -N=1 -mn_type="OS_MESH" -num_ms=256 -ms_rows=16 -ms_cols=16 -rn_bw=256 -dn_bw=32 -accumulation_buffer=1 -mem_ctrl="TPU_OS_DENSE" -rn_type="TEMPORALRN" -generate_tile=1

top - 11:52:35 up  2:13,  6 users,  load average: 1.53, 1.53, 1.87
Tasks:   1 total,   0 running,   0 sleeping,   1 stopped,   0 zombie
%Cpu(s):  0.4 us,  0.2 sy,  0.0 ni, 99.4 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
MiB Mem :  63952.6 total,  40864.5 free,  16723.0 used,   6365.1 buff/cache
MiB Swap:   5072.0 total,   5072.0 free,      0.0 used.  46450.6 avail Mem 
    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                                 
  27948 isairom+  20   0  **515716** **513196**   4228 t   0.0   0.8   9:24.85 stonne                                  

Memory after the commit with 300 iterations with pure STONNE, same parameters:

top - 12:05:49 up  2:26,  7 users,  load average: 1.58, 1.62, 1.80
Tasks:   1 total,   0 running,   0 sleeping,   1 stopped,   0 zombie
%Cpu(s):  6.5 us,  0.4 sy,  0.0 ni, 93.1 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
MiB Mem :  63952.6 total,  40154.7 free,  16957.7 used,   6840.2 buff/cache
MiB Swap:   5072.0 total,   5072.0 free,      0.0 used.  46204.4 avail Mem 
    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                                 
  30501 isairom+  20   0   **71808  69292**   4228 t   0.0   0.1   9:37.23 stonne   

Memory status after the first iteration:

top - 12:08:12 up  2:29,  7 users,  load average: 0.54, 1.24, 1.63
Tasks:   1 total,   0 running,   0 sleeping,   1 stopped,   0 zombie
%Cpu(s):  0.4 us,  0.2 sy,  0.0 ni, 99.4 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
MiB Mem :  63952.6 total,  40326.9 free,  16779.3 used,   6846.4 buff/cache
MiB Swap:   5072.0 total,   5072.0 free,      0.0 used.  46379.2 avail Mem 
    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                                 
  32378 isairom+  20   0    **9136**   **6280**   3912 t   0.0   0.0   0:02.81 stonne

I was able to identify and solve with a workaround further memory leaks in the DataPackage queues of the HW components, but such code fixes demand very high effort (i.e. if you have interest, we can discuss further in another thread). If you need me to run other tests, please let me know.

Regards,

Isai.